### PR TITLE
write basic service and add Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,13 @@
 # Test binary, built with `go test -c`
 *.test
 
+# Editor files
+.idea/
+*.iml
+*.swp
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/janduursma/rumor-api
+
+go 1.17

--- a/main.go
+++ b/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+var build = "develop"
+
+func main() {
+	log.Println("starting service", build)
+	defer log.Println("service ended")
+
+	shutdown := make(chan os.Signal, 1)
+	signal.Notify(shutdown, syscall.SIGINT, syscall.SIGTERM)
+	<-shutdown
+
+	log.Println("stopping service")
+}

--- a/makefile
+++ b/makefile
@@ -1,0 +1,16 @@
+SHELL := /bin/bash
+
+run:
+	go run main.go
+
+VERSION := 1.0
+
+all: service
+
+service:
+	docker build \
+		-f zarf/docker/Dockerfile \
+		-t service:$(VERSION) \
+		--build-arg BUILD_REF=$(VERSION) \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		.

--- a/zarf/docker/Dockerfile
+++ b/zarf/docker/Dockerfile
@@ -1,0 +1,26 @@
+# Build the Go Binary
+FROM golang:1.17 as build_basic_service
+ENV CGO_ENABLED 0
+ARG BUILD_REF
+
+COPY . /service
+
+WORKDIR /service
+RUN go build -ldflags "-X main.build=${BUILD_REF}"
+
+
+# Run the Go Binary
+FROM alpine:3.15
+
+ARG BUILD_DATE
+ARG BUILD_REF
+
+COPY --from=build_basic_service /service /service/service
+
+WORKDIR /service
+CMD ["./service"]
+
+LABEL org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.title="service" \
+      org.opencontainers.image.authors="Jan Duursma <me@janduursma.com>" \
+      org.opencontainers.image.revision="${BUILD_REF}"


### PR DESCRIPTION
write a basic service that starts and safely shuts down, with a makefile to run the service, and a Dockerfile to containerize the service.

resolves #9